### PR TITLE
Enforce plain list types on positions/values between converters.

### DIFF
--- a/gradient_free_optimizers/converter.py
+++ b/gradient_free_optimizers/converter.py
@@ -6,10 +6,11 @@ import numpy as np
 import pandas as pd
 
 from functools import reduce
+from typing import Optional
 
 
 class Converter:
-    def __init__(self, search_space):
+    def __init__(self, search_space: dict) -> None:
         self.n_dimensions = len(search_space)
         self.search_space = search_space
         self.para_names = list(search_space.keys())
@@ -39,25 +40,25 @@ class Converter:
         return wrapper
 
     @returnNoneIfArgNone
-    def position2value(self, position):
+    def position2value(self, position: Optional[list]) -> Optional[list]:
         value = []
 
         for n, space_dim in enumerate(self.search_space_values):
             value.append(space_dim[position[n]])
 
-        return np.array(value)
+        return value
 
     @returnNoneIfArgNone
-    def value2position(self, value):
+    def value2position(self, value: Optional[list]) -> Optional[list]:
         position = []
         for n, space_dim in enumerate(self.search_space_values):
-            pos = np.abs(value[n] - space_dim).argmin()
-            position.append(pos)
+            pos = np.abs(value[n] - np.array(space_dim)).argmin()
+            position.append(int(pos))
 
-        return np.array(position).astype(int)
+        return position
 
     @returnNoneIfArgNone
-    def value2para(self, value):
+    def value2para(self, value: Optional[list]) -> Optional[dict]:
         para = {}
         for key, p_ in zip(self.para_names, value):
             para[key] = p_
@@ -65,16 +66,16 @@ class Converter:
         return para
 
     @returnNoneIfArgNone
-    def para2value(self, para):
+    def para2value(self, para: Optional[dict]) -> Optional[list]:
 
         value = []
         for para_name in self.para_names:
             value.append(para[para_name])
 
-        return np.array(value)
+        return value
 
     @returnNoneIfArgNone
-    def values2positions(self, values):
+    def values2positions(self, values: Optional[list]) -> Optional[list]:
         positions_temp = []
         values_np = np.array(values)
 
@@ -91,34 +92,40 @@ class Converter:
         return positions
 
     @returnNoneIfArgNone
-    def positions2values(self, positions):
-        values_temp = []
+    def positions2values(self, positions: Optional[list]) -> Optional[list]:
+        values = []
         positions_np = np.array(positions)
 
         for n, space_dim in enumerate(self.search_space_values):
             pos_1d = positions_np[:, n]
             value_ = np.take(space_dim, pos_1d, axis=0)
-            values_temp.append(value_)
+            values.append(value_)
 
-        values = list(np.array(values_temp).T)
+        values = [list(t) for t in zip(*values)]
         return values
 
     @returnNoneIfArgNone
-    def positions_scores2memory_dict(self, positions, scores):
+    def positions_scores2memory_dict(
+        self, positions: Optional[list], scores: Optional[list]
+    ) -> Optional[dict]:
         value_tuple_list = list(map(tuple, positions))
         memory_dict = dict(zip(value_tuple_list, scores))
 
         return memory_dict
 
     @returnNoneIfArgNone
-    def memory_dict2positions_scores(self, memory_dict):
+    def memory_dict2positions_scores(
+        self, memory_dict: Optional[dict]
+    ) -> Optional[tuple[list, list]]:
         positions = [np.array(pos).astype(int) for pos in list(memory_dict.keys())]
         scores = list(memory_dict.values())
 
         return positions, scores
 
     @returnNoneIfArgNone
-    def dataframe2memory_dict(self, dataframe):
+    def dataframe2memory_dict(
+        self, dataframe: Optional[pd.DataFrame]
+    ) -> Optional[dict]:
         parameter = set(self.search_space.keys())
         memory_para = set(dataframe.columns)
 
@@ -143,7 +150,9 @@ class Converter:
             return {}
 
     @returnNoneIfArgNone
-    def memory_dict2dataframe(self, memory_dict):
+    def memory_dict2dataframe(
+        self, memory_dict: Optional[dict]
+    ) -> Optional[pd.DataFrame]:
         positions, score = self.memory_dict2positions_scores(memory_dict)
         values = self.positions2values(positions)
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -616,3 +616,33 @@ def test_memory_dict2dataframe_0(test_input, expected):
     dataframe = dataframe[expected.columns]
 
     assert dataframe.equals(expected)
+
+
+""" --- test search spaces with mixed int/float types --- """
+
+
+def test_mixed_type_search_space():
+    def objective_function(para):
+        nonlocal para_types
+        for v, t in zip(para.values(), para_types):
+            assert isinstance(v, t)
+        score = 0
+        for x1 in range(para["x1"]):
+            score += -(x1 ** 2) + para["x2"] + 100
+        return score
+
+    search_space = {
+        "x1": range(10, 20),
+        "x2": np.arange(1, 2, 0.1),
+    }
+    para_types = [int, float]
+    expected_pos = [1, 9]
+
+    opt = RandomSearchOptimizer(search_space)
+    opt.search(objective_function, n_iter=100)
+
+    for best_para_val, expected_p, dim_space, p_type in zip(
+        opt.best_para.values(), expected_pos, search_space.values(), para_types
+    ):
+        assert best_para_val == dim_space[expected_p]
+        assert isinstance(best_para_val, p_type)


### PR DESCRIPTION
To Resolve #15, similar as SimonBlanke/Hyperactive#34. In the cases of search space has both float and int types, the returned best integer paras are converted to float by numpy, which could raise type error in the following model evaluation with the passed-in best paras. This PR enforce plain Python list type on positions/values passed into/out of converter functions, and removes the numpy array conversions.