### PR TITLE
Fix python 3.11 random seeding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@master

--- a/gradient_free_optimizers/utils.py
+++ b/gradient_free_optimizers/utils.py
@@ -15,7 +15,7 @@ def set_random_seed(nth_process, random_state):
         nth_process = 0
 
     if random_state is None:
-        random_state = np.random.randint(0, high=2 ** 31 - 2, dtype=np.int64)
+        random_state = np.random.randint(0, high=2 ** 31 - 2, dtype=np.int64).item()
 
     random.seed(random_state + nth_process)
     np.random.seed(random_state + nth_process)


### PR DESCRIPTION
The issue originated from https://github.com/SimonBlanke/Hyperactive/pull/58 can be summarized around seeding pyhton seeds with non pytonic values. At it's core it is as follows:
```
>>> import numpy as np
>>> a = np.random.randint(0, high=2 ** 31 - 2, dtype=np.int64)
>>> type(a)
<class 'numpy.int64'>
>>> type(a.item())
<class 'int'>

>>> a
518627337
>>> a.item()
518627337 # confirms the value doesn't change
 ```

Thus, with the new requirements for python 3.11 to accept python types, we can convert the `numpy int` to a pythonic `int`.

The python 3.11 job succeeds - https://github.com/23pointsNorth/Gradient-Free-Optimizers/actions/runs/3427292210/jobs/5710490773  though some issues with 3.5/6 are flagged, but I am unsure if they are related to this change or how python versions are selected from [here](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)

Hope this help (the rabbit hole at https://github.com/holoviz/param/issues/602 was interesting, but hopefully the fix here would be much simpler).
