### PR TITLE
Add HilbertGridSearchOptimizer for space-filling curve traversal

### DIFF
--- a/src/gradient_free_optimizers/optimizers/grid/grid_search.py
+++ b/src/gradient_free_optimizers/optimizers/grid/grid_search.py
@@ -5,6 +5,7 @@
 from ..base_optimizer import BaseOptimizer
 from .diagonal_grid_search import DiagonalGridSearchOptimizer
 from .orthogonal_grid_search import OrthogonalGridSearchOptimizer
+from .hilbert_grid_search import HilbertGridSearchOptimizer
 
 
 class GridSearchOptimizer(BaseOptimizer):
@@ -58,9 +59,18 @@ class GridSearchOptimizer(BaseOptimizer):
                 nth_process=nth_process,
                 step_size=step_size,
             )
+        elif direction == "hilbert":
+            self.grid_search_opt = HilbertGridSearchOptimizer(
+                search_space=search_space,
+                initialize=initialize,
+                constraints=constraints,
+                random_state=random_state,
+                rand_rest_p=rand_rest_p,
+                nth_process=nth_process,
+                step_size=step_size,
+            )
         else:
-            msg = ""
-            raise Exception(msg)
+            raise ValueError("Invalid direction. Choose 'orthogonal', 'diagonal', or 'hilbert'.")
 
     @BaseOptimizer.track_new_pos
     def iterate(self):

--- a/src/gradient_free_optimizers/optimizers/grid/hilbert_grid_search.py
+++ b/src/gradient_free_optimizers/optimizers/grid/hilbert_grid_search.py
@@ -1,0 +1,55 @@
+# gradient_free_optimizers/hilbert_grid_search.py
+# Author: Simon Blanke
+# Email: simon.blanke@yahoo.com
+# License: MIT License
+
+import numpy as np
+from numpy_hilbert_curve import decode
+from ..base_optimizer import BaseOptimizer
+
+
+class HilbertGridSearchOptimizer(BaseOptimizer):
+    def __init__(
+        self,
+        search_space,
+        initialize={"grid": 4, "random": 2, "vertices": 4},
+        constraints=[],
+        random_state=None,
+        rand_rest_p=0,
+        nth_process=None,
+        step_size=1,
+    ):
+        super().__init__(
+            search_space=search_space,
+            initialize=initialize,
+            constraints=constraints,
+            random_state=random_state,
+            rand_rest_p=rand_rest_p,
+            nth_process=nth_process,
+        )
+        self.step_size = step_size
+        self.Z = 0  # Current Hilbert integer
+        self.valid_count = 0  # Counter for valid points
+
+    def hilbert_move(self):
+        while True:
+            # Decode the current Hilbert integer to get an nD point
+            point = decode(np.array([self.Z]), self.conv.n_dim, self.conv.n_dim)[0]
+            self.Z += 1
+            # Check if the point is within the grid bounds
+            if all(point[i] < self.conv.dim_sizes[i] for i in range(self.conv.n_dim)):
+                self.valid_count += 1
+                # Take every step_size-th valid point
+                if self.valid_count % self.step_size == 1:
+                    return np.array(point)
+            # Continue if point is out of bounds
+
+    @BaseOptimizer.track_new_pos
+    def iterate(self):
+        pos_new = self.hilbert_move()
+        pos_new = self.conv2pos(pos_new)
+        return pos_new
+
+    @BaseOptimizer.track_new_score
+    def evaluate(self, score_new):
+        BaseOptimizer.evaluate(self, score_new)


### PR DESCRIPTION
Fixes: #65 
## Motivation

The current grid-search implementation in Gradient-Free-Optimizers, as noted in [issue #65](https://github.com/SimonBlanke/Gradient-Free-Optimizers/issues/65), starts traversal from a corner of the search space and follows paths close to previously explored points. This leads to poor exploration when the number of iterations is much smaller than the search space size, limiting the algorithm’s ability to effectively cover n-dimensional spaces. By introducing a Hilbert curve-based traversal, this PR aims to improve exploration by generating points in a space-filling manner, ensuring better coverage across all dimensions, particularly for high-dimensional problems with limited iterations

## Description of the changes

This PR adds a new HilbertGridSearchOptimizer class that uses a Hilbert curve to traverse the search space, addressing the exploration limitations outlined in issue #65. The changes include:

New File: Created hilbert_grid_search.py with the HilbertGridSearchOptimizer class:
Inherits from BaseOptimizer, maintaining consistency with OrthogonalGridSearchOptimizer and DiagonalGridSearchOptimizer.
Implements a hilbert_move method that generates grid points along a Hilbert curve using the numpy-hilbert-curve package’s decode function.
Supports the step_size parameter to skip points and filters out-of-bounds coordinates for non-cubic grids.
Uses conv2pos to convert indices to search space positions, ensuring compatibility with existing logic.
Updated grid_search.py:
Added import: from .hilbert_grid_search import HilbertGridSearchOptimizer.
Modified the GridSearchOptimizer class to support a new "hilbert" direction, instantiating HilbertGridSearchOptimizer when selected.