### PR TITLE
Resolve warnings of NumPy library

### DIFF
--- a/src/gradient_free_optimizers/optimizers/smb_opt/smbo.py
+++ b/src/gradient_free_optimizers/optimizers/smb_opt/smbo.py
@@ -58,7 +58,7 @@ class SMBO(BaseOptimizer):
                 search_space_dim = self.conv.search_space[para_name]
 
                 int_idx = np.nonzero(
-                    np.in1d(search_data_dim, search_space_dim)
+                    np.isin(search_data_dim, search_space_dim)
                 )[0]
                 int_idx_list.append(int_idx)
 


### PR DESCRIPTION
# PR Summary
This small PR replaces deprecated `numpy.in1d()` calls with `numpy.isin()` to resolve deprecation warnings while maintaining identical functionality in order to solve:
```python
DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```